### PR TITLE
Pass in the actor on the command line.

### DIFF
--- a/.github/workflows/tbr-bot.yml
+++ b/.github/workflows/tbr-bot.yml
@@ -15,7 +15,7 @@ jobs:
         run: go build ./...
 
       - name: run-a-bot
-        run: ./tbr-audit --org="tailscale" --bugrepo="corp" --repos="corp,tailscale"
+        run: ./tbr-audit --actor=tbr-bot --org="tailscale" --bugrepo="corp" --repos="corp,tailscale"
         env:
           GH_APP_ID: ${{ secrets.GH_APP_ID }}
           GH_APP_INSTALL_ID: ${{ secrets.GH_APP_INSTALL_ID }}

--- a/cmd/tbr-audit/main.go
+++ b/cmd/tbr-audit/main.go
@@ -28,6 +28,7 @@ import (
 type githubInfo struct {
 	org     string
 	bugrepo string
+	actor   string
 }
 
 func mustInt64(env string) int64 {
@@ -64,9 +65,8 @@ func fileFollowupIssue(ctx context.Context, client *github.Client, repo string, 
 	title := fmt.Sprintf("TBR %s/%s/pull/%d followup review", args.org, repo, prNum)
 
 	// all of the followup issues are in corp, no matter the repo of the submitted PR
-	actor := os.Getenv("GITHUB_ACTOR")
 	check := fmt.Sprintf("%s in:title repo:%s/%s author:app/%s", title, args.org,
-		args.bugrepo, actor)
+		args.bugrepo, args.actor)
 	followup, _, err := client.Search.Issues(ctx, check, &github.SearchOptions{
 		ListOptions: github.ListOptions{PerPage: 10}})
 	if err != nil {
@@ -197,6 +197,7 @@ func main() {
 	var args githubInfo
 	flag.StringVar(&args.org, "org", "example-github-organization", "GitHub organization to use")
 	flag.StringVar(&args.bugrepo, "bugrepo", "ToBeReviewedBot", "name of repository to file followup issues in")
+	flag.StringVar(&args.actor, "actor", "actor", "The AppSlug of the GH App running the bot")
 	repos := flag.String("repos", "example-github-repo",
 		"comma-separated list of GitHub repositories to check for to-be-reviewed PRs")
 	flag.Parse()


### PR DESCRIPTION
GITHUB_ACTOR is the GitHub account which triggered the CI
Runner, not the GitHub App we created for this. For example
if I submitted a PR the GITHUB_ACTOR would be my GitHub account,
not the acount created for the bot.

Pass in the actor explicitly on the commandline instead.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>