### PR TITLE
Move configuration out of YAML and into secrets.

### DIFF
--- a/.github/workflows/tbr-bot.yml
+++ b/.github/workflows/tbr-bot.yml
@@ -2,7 +2,7 @@ name: To-Be-Reviewed Bot
 
 on:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '*/10 * * * *'
 
 jobs:
   bot:
@@ -15,8 +15,12 @@ jobs:
         run: go build ./...
 
       - name: run-a-bot
-        run: ./tbr-audit --actor=tbr-bot --org="tailscale" --bugrepo="corp" --repos="corp,tailscale"
+        run: ./tbr-audit
         env:
           GH_APP_ID: ${{ secrets.GH_APP_ID }}
           GH_APP_INSTALL_ID: ${{ secrets.GH_APP_INSTALL_ID }}
           GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          TBRBOT_ORG: ${{ secrets.TBRBOT_ORG }}
+          TBRBOT_BUGREPO: ${{ secrets.TBRBOT_BUGREPO }}
+          TBRBOT_APPNAME: ${{ secrets.TBRBOT_APPNAME }}
+          TBRBOT_REPOLIST: ${{ secrets.TBRBOT_REPOLIST }}


### PR DESCRIPTION
Preparing to open the source: forking the repo should not result
in someone else running a GitHub Action every few minutes watching
Tailscale's OSS repo and filing bugs. Even though the issues they
file would be in their own repo's issue tracker, it would show up
as mentions on our PRs and that would be annoying.

Move the configuration out of the YAML file and into secrets.
Forking the repo won't fork the secrets, a forked repo will
run the action periodically but not do anything.

Since the Actions runner minutes will be free as a public repo,
run the bot a little more often.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>