### PR TITLE
Run every 30 minutes

### DIFF
--- a/.github/workflows/tbr-bot.yml
+++ b/.github/workflows/tbr-bot.yml
@@ -2,7 +2,7 @@ name: To-Be-Reviewed Bot
 
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/30 * * * *'
 
 jobs:
   bot:


### PR DESCRIPTION
Every 10 minutes is too often, it consumes all of its API quota
and starts failing.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>